### PR TITLE
feat: optimise for redshift loader by setting default vals eg dt

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 import sys
 import typing as t
 from functools import cached_property
@@ -67,6 +68,11 @@ class HubspotStream(RESTStream):
         if "user_agent" in self.config:
             headers["User-Agent"] = self.config.get("user_agent")
         return headers
+
+    def post_process(self, row: dict, context: t.Any = None) -> dict | None:
+        """Inject the run's partition timestamp into every record."""
+        row["dt"] = os.environ.get("CURRENT_DATE_MINUTE_LEVEL")
+        return row
 
     def get_new_paginator(self) -> BaseAPIPaginator:
         """Create a new pagination helper instance.
@@ -148,6 +154,7 @@ class DynamicHubspotStream(HubspotStream):
             th.Property("createdAt", th.DateTimeType),
             th.Property("updatedAt", th.DateTimeType),
             th.Property("archived", th.BooleanType),
+            th.Property("dt", th.StringType),
         )
         return schema.to_dict()
 
@@ -216,6 +223,7 @@ class DynamicIncrementalHubspotStream(DynamicHubspotStream):
             th.Property("createdAt", th.DateTimeType),
             th.Property("updatedAt", th.DateTimeType),
             th.Property("archived", th.BooleanType),
+            th.Property("dt", th.StringType),
         )
         if self.replication_key:
             schema.append(
@@ -260,6 +268,9 @@ class DynamicIncrementalHubspotStream(DynamicHubspotStream):
         Returns:
             The resulting record dict, or `None` if the record should be excluded.
         """
+        row = super().post_process(row, context)
+        if row is None:
+            return None
         if self.replication_key:
             val = None
             if props := row.get("properties"):

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -1999,6 +1999,7 @@ class EmailEventsStream(HubspotStream):
             ),
         ),
         Property("portalSubscriptionStatus", StringType),
+        Property("dt", StringType),
     ).to_dict()
 
     @property
@@ -2150,6 +2151,10 @@ class EmailEventsStream(HubspotStream):
         context: Context | None = None,
     ) -> dict | None:
         """Process browser fields to handle arrays and clean up data."""
+        row = super().post_process(row, context)
+        if row is None:
+            return None
+
         # Handle browser object fields that might be arrays
         if "browser" in row and isinstance(row["browser"], dict):
             browser = row["browser"]
@@ -2322,6 +2327,7 @@ class WebEventsStream(HubspotStream):
                 Property("hs_custom_metric_5", NumberType),
             ),
         ),
+        Property("dt", StringType),
     ).to_dict()
 
     @property
@@ -2569,6 +2575,10 @@ class WebEventsStream(HubspotStream):
         context: Context | None = None,
     ) -> dict | None:
         """Process web event records."""
+        row = super().post_process(row, context)
+        if row is None:
+            return None
+
         # Convert occurredAt to datetime format if it's a timestamp
         if "occurredAt" in row and isinstance(row["occurredAt"], int):
             row["occurredAt"] = datetime.datetime.fromtimestamp(


### PR DESCRIPTION
https://hgdata.atlassian.net/browse/RGI-588?atlOrigin=eyJpIjoiZDJmYjU4NGJiZTk2NDE5YWJhYTBkODBhZDlhYTZjMzEiLCJwIjoiaiJ9

To be deployed with https://github.com/HGData/mk-data-ingestion-core/pull/242

Optimisation of redshift loader: add default fields eg dt to the json data as copying with an extra col is more performant than running an update in redshift to backfill later