### PR TITLE
fix: QA-297 use single hubspot domain variable for all API calls

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -28,6 +28,10 @@ if sys.version_info < (3, 11):
 
 _Auth = t.Callable[[requests.PreparedRequest], requests.PreparedRequest]
 
+# Single source of truth for the HubSpot API domain used by all streams and
+# requests. Override here to point the tap at a different host.
+BASE_HUBSPOT_API_URL = "https://api.hubapi.com"
+
 
 class HubspotStream(RESTStream):
     """tap-hubspot stream class."""
@@ -35,7 +39,7 @@ class HubspotStream(RESTStream):
     @property
     def url_base(self) -> str:
         """Returns base url."""
-        return "https://api.hubapi.com/"
+        return f"{BASE_HUBSPOT_API_URL}/"
 
     records_jsonpath = "$[*]"  # Or override `parse_response`.
 
@@ -51,7 +55,7 @@ class HubspotStream(RESTStream):
         if "refresh_token" in self.config:
             return HubSpotOAuthAuthenticator(
                 self,
-                auth_endpoint="https://api.hubapi.com/oauth/v1/token",
+                auth_endpoint=f"{BASE_HUBSPOT_API_URL}/oauth/v1/token",
             )
         return BearerTokenAuthenticator(
             self,
@@ -163,7 +167,7 @@ class DynamicHubspotStream(HubspotStream):
         session.auth = self.authenticator
 
         resp = session.get(
-            f"https://api.hubapi.com/crm/v3/properties/{self.name}",
+            f"{BASE_HUBSPOT_API_URL}/crm/v3/properties/{self.name}",
         )
         resp.raise_for_status()
         results = resp.json().get("results", [])

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -10,6 +10,7 @@ import requests
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_hubspot.client import (
+    BASE_HUBSPOT_API_URL,
     DynamicIncrementalHubspotStream,
     HubspotStream,
 )
@@ -52,7 +53,7 @@ class ContactStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
     def get_child_context(self, record: dict, context: Context | None) -> dict:
         """Return a context dictionary for child streams."""
@@ -124,7 +125,7 @@ class UsersStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/settings/v3"
+        return f"{BASE_HUBSPOT_API_URL}/settings/v3"
 
 
 class OwnersStream(HubspotStream):
@@ -158,7 +159,7 @@ class OwnersStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class TicketPipelineStream(HubspotStream):
@@ -213,7 +214,7 @@ class TicketPipelineStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm-pipelines/v1"
+        return f"{BASE_HUBSPOT_API_URL}/crm-pipelines/v1"
 
 
 class DealPipelineStream(HubspotStream):
@@ -268,7 +269,7 @@ class DealPipelineStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm-pipelines/v1"
+        return f"{BASE_HUBSPOT_API_URL}/crm-pipelines/v1"
 
 
 class EmailSubscriptionStream(HubspotStream):
@@ -304,7 +305,7 @@ class EmailSubscriptionStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/email/public/v1"
+        return f"{BASE_HUBSPOT_API_URL}/email/public/v1"
 
 
 class PropertyTicketStream(HubspotStream):
@@ -367,7 +368,7 @@ class PropertyTicketStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyDealStream(HubspotStream):
@@ -431,7 +432,7 @@ class PropertyDealStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyContactStream(HubspotStream):
@@ -494,7 +495,7 @@ class PropertyContactStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyCompanyStream(HubspotStream):
@@ -557,7 +558,7 @@ class PropertyCompanyStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyProductStream(HubspotStream):
@@ -620,7 +621,7 @@ class PropertyProductStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyLineItemStream(HubspotStream):
@@ -683,7 +684,7 @@ class PropertyLineItemStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyEmailStream(HubspotStream):
@@ -746,7 +747,7 @@ class PropertyEmailStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyPostalMailStream(HubspotStream):
@@ -809,7 +810,7 @@ class PropertyPostalMailStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyGoalStream(HubspotStream):
@@ -872,7 +873,7 @@ class PropertyGoalStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyCallStream(HubspotStream):
@@ -935,7 +936,7 @@ class PropertyCallStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyMeetingStream(HubspotStream):
@@ -998,7 +999,7 @@ class PropertyMeetingStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyTaskStream(HubspotStream):
@@ -1061,7 +1062,7 @@ class PropertyTaskStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyCommunicationStream(HubspotStream):
@@ -1124,7 +1125,7 @@ class PropertyCommunicationStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PropertyNotesStream(HubspotStream):
@@ -1187,7 +1188,7 @@ class PropertyNotesStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
     def get_records(self, context: Context | None) -> t.Iterable[dict[str, t.Any]]:
         """Merges all the property stream data into a single property table."""
@@ -1250,7 +1251,7 @@ class CompanyStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class DealStream(DynamicIncrementalHubspotStream):
@@ -1276,7 +1277,7 @@ class DealStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
     @property
     def page_size(self) -> int:
@@ -1322,7 +1323,7 @@ class DealStream(DynamicIncrementalHubspotStream):
             return {}
 
         # Prepare the request
-        url = f"https://api.hubapi.com/crm/v4/associations/deal/{association_type}/batch/read"
+        url = f"{BASE_HUBSPOT_API_URL}/crm/v4/associations/deal/{association_type}/batch/read"
         payload = {"inputs": [{"id": deal_id} for deal_id in deal_ids]}
 
         headers = {
@@ -1559,7 +1560,7 @@ class FeedbackSubmissionsStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class LineItemStream(DynamicIncrementalHubspotStream):
@@ -1585,7 +1586,7 @@ class LineItemStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class ProductStream(HubspotStream):
@@ -1628,7 +1629,7 @@ class ProductStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class TicketStream(HubspotStream):
@@ -1670,7 +1671,7 @@ class TicketStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class QuoteStream(HubspotStream):
@@ -1712,7 +1713,7 @@ class QuoteStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class GoalStream(DynamicIncrementalHubspotStream):
@@ -1737,7 +1738,7 @@ class GoalStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class CallStream(DynamicIncrementalHubspotStream):
@@ -1762,7 +1763,7 @@ class CallStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class CommunicationStream(DynamicIncrementalHubspotStream):
@@ -1787,7 +1788,7 @@ class CommunicationStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class EmailStream(DynamicIncrementalHubspotStream):
@@ -1803,7 +1804,7 @@ class EmailStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class MeetingStream(DynamicIncrementalHubspotStream):
@@ -1828,7 +1829,7 @@ class MeetingStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class NoteStream(DynamicIncrementalHubspotStream):
@@ -1853,7 +1854,7 @@ class NoteStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class PostalMailStream(DynamicIncrementalHubspotStream):
@@ -1878,7 +1879,7 @@ class PostalMailStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class TaskStream(DynamicIncrementalHubspotStream):
@@ -1903,7 +1904,7 @@ class TaskStream(DynamicIncrementalHubspotStream):
     @property
     def url_base(self) -> str:
         """Returns an updated path which includes the api version."""
-        return "https://api.hubapi.com/crm/v3"
+        return f"{BASE_HUBSPOT_API_URL}/crm/v3"
 
 
 class EmailEventsStream(HubspotStream):
@@ -2005,7 +2006,7 @@ class EmailEventsStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns base url for email events."""
-        return "https://api.hubapi.com"
+        return BASE_HUBSPOT_API_URL
 
     def get_next_page_token(
         self,
@@ -2333,7 +2334,7 @@ class WebEventsStream(HubspotStream):
     @property
     def url_base(self) -> str:
         """Returns base url for web events."""
-        return "https://api.hubapi.com"
+        return BASE_HUBSPOT_API_URL
 
     def get_event_types(self) -> list[str]:
         """Fetch all available event types from the API."""


### PR DESCRIPTION
## What
Introduces a single `BASE_HUBSPOT_API_URL` constant in `tap_hubspot/client.py` and references it across the tap instead of hardcoding `https://api.hubapi.com`.

## Why
QA-297 — the HubSpot API domain was hardcoded in ~41 places. We want to run the tap against a **HubSpot simulator** (a FastAPI mock that stands in for the real HubSpot API) for our connector pipeline testing, instead of hitting `https://api.hubapi.com`.

With the domain hardcoded across 40+ spots, the only ways to point the tap at the simulator were patching every occurrence or intercepting the API hostname at the network/DNS layer. Centralizing it into a single `BASE_HUBSPOT_API_URL` constant means the endpoint can be swapped in one place — making it straightforward to redirect the tap at the simulator and test against mock data without changing the pull logic.

## Changes
- `client.py`: new `BASE_HUBSPOT_API_URL` constant; base url, OAuth endpoint, and dynamic property lookup now use it
- `streams.py`: all 38 stream `url_base` overrides (and the inline associations URL) now use the constant

## Verification
- `python3 -m py_compile` passes on both files
- grep confirms no hardcoded `api.hubapi.com` remains except the constant definition
- All f-strings produce URLs identical to the originals (mechanical refactor)

Jira: https://hgdata.atlassian.net/browse/QA-297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
