### PR TITLE
QA-297: add HG_SIMULATOR_TAP_HUBSPOT_BASE_URL override for simulator routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ limit_events_month: 12
 # Result: Uses 2023-07-21 instead of the old 2020-01-01 state
 ```
 
+## Environment Variables
+
+### `HG_SIMULATOR_TAP_HUBSPOT_BASE_URL` (dev only)
+
+Optional override for the HubSpot API host. When set, every request the tap makes — both data calls and the OAuth token endpoint (`/oauth/v1/token`) — is sent to this host instead of `https://api.hubapi.com`. It is read directly from the process environment in `tap_hubspot/client.py` (it replaces the default value of the `BASE_HUBSPOT_API_URL` constant); it is not a `config.json` setting. A trailing slash, if present, is stripped.
+
+This variable is injected externally — it is not normally set by the tap or its callers. In MK's data ingestion pipeline it is supplied by `mk-airflow` (`dags/data_ingestion_core.py:_apply_simulator_overrides`), which reads the `mdi_simulator_overrides` MWAA Airflow Variable and writes the resulting env vars into the pull task's ECS `containerOverrides`. That injection is gated behind `env == "dev"`, so the variable is never set on production pull tasks. When unset (the default everywhere outside the dev MWAA), the tap behaves identically to upstream and hits the real HubSpot API.
+
+Intended use is to redirect a tenant's pull task at a hosted HubSpot simulator (`rgip-connector-simulators`, e.g. `https://hubspot-sim-01.hip.staging.hginsights.com`) for integration testing without touching production credentials.
+
 ## Elastic License 2.0
 
 The licensor grants you a non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable license to use, copy, distribute, make available, and prepare derivative works of the software.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ limit_events_month: 12
 
 ### `HG_SIMULATOR_TAP_HUBSPOT_BASE_URL` (dev only)
 
-Optional override for the HubSpot API host. When set, every request the tap makes — both data calls and the OAuth token endpoint (`/oauth/v1/token`) — is sent to this host instead of `https://api.hubapi.com`. It is read directly from the process environment in `tap_hubspot/client.py` (it replaces the default value of the `BASE_HUBSPOT_API_URL` constant); it is not a `config.json` setting. A trailing slash, if present, is stripped.
+Optional override for the HubSpot API host. When set, every request the tap makes — both data calls and the OAuth token endpoint (`/oauth/v1/token`) — is sent to this host instead of `https://api.hubapi.com`. It is read directly from the process environment in `tap_hubspot/client.py`, where it conditionally overrides the `BASE_HUBSPOT_API_URL` constant (which otherwise stays at its `https://api.hubapi.com` default); it is not a `config.json` setting. A trailing slash, if present, is stripped.
 
 This variable is injected externally — it is not normally set by the tap or its callers. In MK's data ingestion pipeline it is supplied by `mk-airflow` (`dags/data_ingestion_core.py:_apply_simulator_overrides`), which reads the `mdi_simulator_overrides` MWAA Airflow Variable and writes the resulting env vars into the pull task's ECS `containerOverrides`. That injection is gated behind `env == "dev"`, so the variable is never set on production pull tasks. When unset (the default everywhere outside the dev MWAA), the tap behaves identically to upstream and hits the real HubSpot API.
 

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -29,11 +29,15 @@ if sys.version_info < (3, 11):
 _Auth = t.Callable[[requests.PreparedRequest], requests.PreparedRequest]
 
 # Single source of truth for the HubSpot API domain used by all streams and
-# requests. Defaults to the real HubSpot API; set HG_SIMULATOR_TAP_HUBSPOT_BASE_URL
-# to point the tap at a simulator host instead (dev/test only — unset in prod).
-BASE_HUBSPOT_API_URL = os.environ.get(
-    "HG_SIMULATOR_TAP_HUBSPOT_BASE_URL", "https://api.hubapi.com"
-).rstrip("/")
+# requests.
+BASE_HUBSPOT_API_URL = "https://api.hubapi.com"
+
+# Simulator override (dev/test only): when HG_SIMULATOR_TAP_HUBSPOT_BASE_URL is
+# set, route all requests at the simulator host instead of the real API. Unset
+# in prod, so prod behaviour is unchanged.
+_SIMULATOR_BASE_URL = os.environ.get("HG_SIMULATOR_TAP_HUBSPOT_BASE_URL")
+if _SIMULATOR_BASE_URL:
+    BASE_HUBSPOT_API_URL = _SIMULATOR_BASE_URL.rstrip("/")
 
 
 class HubspotStream(RESTStream):

--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -29,8 +29,11 @@ if sys.version_info < (3, 11):
 _Auth = t.Callable[[requests.PreparedRequest], requests.PreparedRequest]
 
 # Single source of truth for the HubSpot API domain used by all streams and
-# requests. Override here to point the tap at a different host.
-BASE_HUBSPOT_API_URL = "https://api.hubapi.com"
+# requests. Defaults to the real HubSpot API; set HG_SIMULATOR_TAP_HUBSPOT_BASE_URL
+# to point the tap at a simulator host instead (dev/test only — unset in prod).
+BASE_HUBSPOT_API_URL = os.environ.get(
+    "HG_SIMULATOR_TAP_HUBSPOT_BASE_URL", "https://api.hubapi.com"
+).rstrip("/")
 
 
 class HubspotStream(RESTStream):


### PR DESCRIPTION
## What

Keep the single `BASE_HUBSPOT_API_URL` constant (introduced in QA-297 / #11) at its real-API default, and add **separate conditional logic** that only overrides it when the `HG_SIMULATOR_TAP_HUBSPOT_BASE_URL` env var is set.

```python
BASE_HUBSPOT_API_URL = "https://api.hubapi.com"

# Simulator override (dev/test only)
_SIMULATOR_BASE_URL = os.environ.get("HG_SIMULATOR_TAP_HUBSPOT_BASE_URL")
if _SIMULATOR_BASE_URL:
    BASE_HUBSPOT_API_URL = _SIMULATOR_BASE_URL.rstrip("/")
```

## Why

This is the tap-side hook for the connector E2E simulator mechanism (parallel to `SIMULATOR_TAP_SALESFORCE_LOGIN_URL` in mk-tap-salesforce #24). It lets the HubSpot pull task be redirected at the hosted simulator (`hubspot-sim-01.hip.staging.hginsights.com`) in dev MWAA, with **zero change to prod behaviour**.

The env var name is the literal key the test harness injects:
- `HubspotSimulatorOverrideEntry` in `rgip-connector-tests/lib/mwaa/types.ts`
- applied by `_apply_simulator_overrides()` in `mk-airflow`, gated on `env == "dev"`

## Scope / behaviour

| Case | `HG_SIMULATOR_TAP_HUBSPOT_BASE_URL` | Resolved base URL |
|---|---|---|
| Prod / normal | unset (or empty) | `https://api.hubapi.com` (real API) |
| Dev sim run | sim host | the simulator host |

- The default constant `BASE_HUBSPOT_API_URL = "https://api.hubapi.com"` is left as-is; the simulator value is applied via a separate conditional, so all existing usages stay unchanged.
- Covers **both** data calls (`url_base`) and the OAuth token endpoint (`{base}/oauth/v1/token`), since both derive from this one constant.
- `.rstrip("/")` guards against double slashes if the override is set with a trailing slash.
- Backwards compatible: unset/empty → identical to current behaviour.

## Test

Verified the env resolution: unset/empty → `api.hubapi.com`; set (with trailing slash) → simulator host with clean `/crm/v3` derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
